### PR TITLE
Update 'init' to run without git pull

### DIFF
--- a/maestro.sh
+++ b/maestro.sh
@@ -1362,31 +1362,35 @@ case $1 in
     ;;
 #*  init                            create an environemnt with all the
 #*                                  repos defined in the config, in order
-#*                                  to get a running knowledge base.
+#*                                  to get a running knowledge base
+#*  reinit                          update reclass environment without
+#*                                  pulling repos
     init|reinit)
         shift
         $_mkdir -p "$workdir"
-        for g in ${!toclone[@]} ; do
-            git_dest=""
-            if [ -n "${inventorydirs[$g]}" ] ; then
-                git_dest="${inventorydirs[$g]}"
-            elif [ -n "${playbookdirs[$g]}" ] ; then
-                git_dest="${playbookdirs[$g]}"
-            elif [ -n "${localdirs[$g]}" ] ; then
-                git_dest="${localdirs[$g]}"
-            else
-                error "there is no corresponding directory defined" \
-                      "in your config for $g"
-            fi
-            if [ -d "$git_dest/.git" ] ; then
-                echo "update repository $g"
-                $_git -C "$git_dest" pull
-            else
-                $_mkdir -p $git_dest
-                [ -n "${toclone[$g]}" ] || continue
-                $_git clone "${toclone[$g]}" "$git_dest"
-            fi
-        done
+        if [ $1 = init ] ; then
+            for g in ${!toclone[@]} ; do
+                git_dest=""
+                if [ -n "${inventorydirs[$g]}" ] ; then
+                    git_dest="${inventorydirs[$g]}"
+                elif [ -n "${playbookdirs[$g]}" ] ; then
+                    git_dest="${playbookdirs[$g]}"
+                elif [ -n "${localdirs[$g]}" ] ; then
+                    git_dest="${localdirs[$g]}"
+                else
+                    error "there is no corresponding directory defined" \
+                          "in your config for $g"
+                fi
+                if [ -d "$git_dest/.git" ] ; then
+                    echo "update repository $g"
+                    $_git -C "$git_dest" pull
+                else
+                    $_mkdir -p $git_dest
+                    [ -n "${toclone[$g]}" ] || continue
+                    $_git clone "${toclone[$g]}" "$git_dest"
+                fi
+            done
+        fi
         echo "Re-create the inventory. Note: there will be warnings for duplicates"
         echo "etc. "
         $_mkdir -p $inventorydir/{nodes,classes}

--- a/maestro.sh
+++ b/maestro.sh
@@ -1360,7 +1360,7 @@ case $1 in
         print_help
         exit 0
     ;;
-#*  init [directory]                create an environemnt with all the
+#*  init                            create an environemnt with all the
 #*                                  repos defined in the config, in order
 #*                                  to get a running knowledge base.
     init|reinit)


### PR DESCRIPTION
I'm playing around with reclass and added new hosts and new classes in a new branch of `servers-reclass-env`. To run `maestro.sh` towards the new hosts I need to update the corresponding Ansible inventory.

When running `maestro.sh init` this will fail with:
```
+ for g in '${!toclone[@]}'
+ git_dest=
+ '[' -n /home/ganto/Documents/inofix/kb/servers-reclass-env ']'
+ git_dest=/home/ganto/Documents/inofix/kb/servers-reclass-env
+ '[' -d /home/ganto/Documents/inofix/kb/servers-reclass-env/.git ']'
+ echo 'update repository inofix_inv'
update repository inofix_inv
+ /usr/bin/git -C /home/ganto/Documents/inofix/kb/servers-reclass-env pull
There is no tracking information for the current branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>

If you wish to set tracking information for this branch you can do so with:

    git branch --set-upstream-to=origin/<branch> home_oasis

```

So I thought I could use the already accepted `reinit` to re-initialize the inventory, without updating the repositories. At this occasion I also found that the documented `init [directory]` argument is never used in the code anymore. It probably used to be a way to define `$workdir`, but I guess that this shouldn't be set so spontaneously anymore.