### PR TITLE
Correctly detect OS code name which contains space

### DIFF
--- a/maestro.sh
+++ b/maestro.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 ########################################################################
-#** Version: v1.2-36-gb7bd28f
+#** Version: v1.2-40-ga3b0dae
 #* This script connects meta data about host projects with concrete
 #* configuration files and even configuration management solutions.
 #*
@@ -730,7 +730,10 @@ connect_node()
     remote_os_name=${remote_os[2]}
     remote_os_release=${remote_os[3]}
     remote_os_codename=${remote_os[4]}
-    answer0="${remote_os[1]} ${remote_os[2]} ${remote_os[3]} ${remote_os[4]}"
+    if [ ${#remote_os[@]} -gt 5 ]; then
+        remote_os_codename="${remote_os_codename} ${remote_os[5]}"
+    fi
+    answer0="${remote_os_distro} ${remote_os_name} ${remote_os_release} ${remote_os_codename}"
     if [ $retval -gt 127 ] ; then
         printf " \e[1;31m${answer0}\n"
     elif [ $retval -gt 0 ] ; then


### PR DESCRIPTION
This is the case e.g. for Fedora:
```
$ lsb_release -d
Description:    Fedora release 24 (Twenty Four)
```