### PR TITLE
Bug fixes

### DIFF
--- a/maestro.sh
+++ b/maestro.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 ########################################################################
-#** Version: v1.3-7-gb21a957
+#** Version: v1.2-77-ge1265de
 #* This script connects meta data about host projects with concrete
 #* configuration files and even configuration management solutions.
 #*
@@ -1516,18 +1516,18 @@ case $1 in
         for d in ${inventorydirs[@]} ; do
             $_find "$d/nodes/" -type d |
                 $_sed 's;'$d'/nodes/;'$inventorydir'/nodes/;' |
-                $_xargs $_mkdir -p
+                $_xargs --no-run-if-empty $_mkdir -p
             $_find "$d/classes/" -type d |
                 $_sed 's;'$d'/classes/;'$inventorydir'/classes/;' |
-                $_xargs $_mkdir -p
+                $_xargs --no-run-if-empty $_mkdir -p
             $_find "$d/nodes/" -name "*.yml" |
                 $_sed \
                   's;\('$d'/nodes/\)\(.*\);\1\2 '$inventorydir'/nodes/\2;' |
-                $_xargs -r -n 2 $_ln -s || true
+                $_xargs --no-run-if-empty --max-args 2 $_ln -s || true
             $_find "$d/classes/" -name "*.yml" |
                 $_sed \
                   's;\('$d'/classes/\)\(.*\);\1\2 '$inventorydir'/classes/\2;' |
-                $_xargs -r -n 2 $_ln -s || true
+                $_xargs --no-run-if-empty --max-args 2 $_ln -s || true
         done
         echo "Re-connect ansible to our reclass inventory"
         [ ! -f "$inventorydir/hosts" ] || $_rm "$inventorydir/hosts"

--- a/maestro.sh
+++ b/maestro.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 ########################################################################
-#** Version: v1.2-77-ge1265de
+#** Version: v1.2-78-gf411a91
 #* This script connects meta data about host projects with concrete
 #* configuration files and even configuration management solutions.
 #*
@@ -1564,6 +1564,10 @@ EOF
             echo "  scp_if_ssh = $Ansible_scp_if_ssh"
             echo "-EOF-"
 
+        fi
+        if [ -z "$ANSIBLE_CONFIG" ] ; then
+            ANSIBLE_CONFIG="$maestrodir/ansible.cfg"
+            export ANSIBLE_CONFIG
         fi
         echo "Installing all necessary ansible-galaxy roles"
         for f in ${playbookdirs[@]}/${galaxyroles} ; do


### PR DESCRIPTION
Fixes:
- Don't fail `init` or `reinit` if a directory defined in `$inventorydirs` doesn't (yet) contain the `{classes,nodes}` subdirectories. There still will be a verbose message to the user anyway:
```
/usr/bin/find: ‘/home/ganto/Documents/inofix/knowledge-base/local-inv/nodes/’: No such file or directory                     
/usr/bin/find: ‘/home/ganto/Documents/inofix/knowledge-base/local-inv/classes/’: No such file or directory
/usr/bin/find: ‘/home/ganto/Documents/inofix/knowledge-base/local-inv/nodes/’: No such file or directory
/usr/bin/find: ‘/home/ganto/Documents/inofix/knowledge-base/local-inv/classes/’: No such file or directory
```
- Make sure `ansible-galaxy` uses the the `$maestrodir/ansible.cfg` to lookup the roles path. Otherwise the galaxy roles will be installed into the global or user-defined `roles_path` but when being executed, they can't be found anymore.